### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/orbitron.css
+++ b/webfonts/orbitron.css
@@ -1,0 +1,45 @@
+/*
+  'Orbitron'
+  https://www.theleagueofmoveabletype.com/orbitron
+
+  Copyright (c) 2009, Matt McInerney <matt@pixelspread.com>,
+  with Reserved Font Name: "Orbitron".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Orbitron';
+  font-weight: 300; /* Light */
+  src: url('orbitron-light-webfont.eot?#iefix') format('embedded-opentype'),
+       url('orbitron-light-webfont.woff') format('woff'),
+       url('orbitron-light-webfont.ttf')  format('truetype'),
+       url('orbitron-light-webfont.svg#webfontZHiKantU') format('svg');
+}
+
+@font-face {
+  font-family: 'Orbitron';
+  font-weight: 500; /* Medium */
+  src: url('orbitron-medium-webfont.eot?#iefix') format('embedded-opentype'),
+       url('orbitron-medium-webfont.woff') format('woff'),
+       url('orbitron-medium-webfont.ttf')  format('truetype'),
+       url('orbitron-medium-webfont.svg#webfontD7xceb3L') format('svg');
+}
+
+@font-face {
+  font-family: 'Orbitron';
+  font-weight: 700; /* Bold */
+  src: url('orbitron-bold-webfont.eot?#iefix') format('embedded-opentype'),
+       url('orbitron-bold-webfont.woff') format('woff'),
+       url('orbitron-bold-webfont.ttf')  format('truetype'),
+       url('orbitron-bold-webfont.svg#webfontMOSYtX6m') format('svg');
+}
+
+@font-face {
+  font-family: 'Orbitron';
+  font-weight: 900; /* Black */
+  src: url('orbitron-black-webfont.eot?#iefix') format('embedded-opentype'),
+       url('orbitron-black-webfont.woff') format('woff'),
+       url('orbitron-black-webfont.ttf')  format('truetype'),
+       url('orbitron-black-webfont.svg#webfontqMYZ91Rj') format('svg');
+}

--- a/webfonts/orbitron.css
+++ b/webfonts/orbitron.css
@@ -11,7 +11,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 300; /* Light */
-  src: url('orbitron-light-webfont.eot'),
+  src: url('orbitron-light-webfont.eot');
   src: url('orbitron-light-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-light-webfont.woff') format('woff'),
        url('orbitron-light-webfont.ttf')  format('truetype'),
@@ -21,7 +21,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 500; /* Medium */
-  src: url('orbitron-medium-webfont.eot'),
+  src: url('orbitron-medium-webfont.eot');
   src: url('orbitron-medium-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-medium-webfont.woff') format('woff'),
        url('orbitron-medium-webfont.ttf')  format('truetype'),
@@ -31,7 +31,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 700; /* Bold */
-  src: url('orbitron-bold-webfont.eot'),
+  src: url('orbitron-bold-webfont.eot');
   src: url('orbitron-bold-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-bold-webfont.woff') format('woff'),
        url('orbitron-bold-webfont.ttf')  format('truetype'),
@@ -41,7 +41,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 900; /* Black */
-  src: url('orbitron-black-webfont.eot'),
+  src: url('orbitron-black-webfont.eot');
   src: url('orbitron-black-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-black-webfont.woff') format('woff'),
        url('orbitron-black-webfont.ttf')  format('truetype'),

--- a/webfonts/orbitron.css
+++ b/webfonts/orbitron.css
@@ -11,6 +11,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 300; /* Light */
+  src: url('orbitron-light-webfont.eot'),
   src: url('orbitron-light-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-light-webfont.woff') format('woff'),
        url('orbitron-light-webfont.ttf')  format('truetype'),
@@ -20,6 +21,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 500; /* Medium */
+  src: url('orbitron-medium-webfont.eot'),
   src: url('orbitron-medium-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-medium-webfont.woff') format('woff'),
        url('orbitron-medium-webfont.ttf')  format('truetype'),
@@ -29,6 +31,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 700; /* Bold */
+  src: url('orbitron-bold-webfont.eot'),
   src: url('orbitron-bold-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-bold-webfont.woff') format('woff'),
        url('orbitron-bold-webfont.ttf')  format('truetype'),
@@ -38,6 +41,7 @@
 @font-face {
   font-family: 'Orbitron';
   font-weight: 900; /* Black */
+  src: url('orbitron-black-webfont.eot'),
   src: url('orbitron-black-webfont.eot?#iefix') format('embedded-opentype'),
        url('orbitron-black-webfont.woff') format('woff'),
        url('orbitron-black-webfont.ttf')  format('truetype'),


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
